### PR TITLE
fix: correct variable assignment for SSH port in command args

### DIFF
--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -22,7 +22,7 @@ func GenerateCommandArgs(c config.SSHConfig) []string {
 	}
 
 	if c.Port != "" {
-		key = "-p " + c.Port
+		port = "-p " + c.Port
 	}
 	return strings.Split(fmt.Sprintf("%s@%s %s %s", user, c.Host, key, port), " ")
 }


### PR DESCRIPTION
Fix: #15 