### PR TITLE
feat: calculate the width of columns based on their content

### DIFF
--- a/internal/interactive/select.go
+++ b/internal/interactive/select.go
@@ -76,24 +76,26 @@ func Select(rows []table.Row, what Selecting) config.SSHConfig {
 	var columns []table.Column
 	if what == SelectConfig {
 		columns = append(columns, []table.Column{
-			{Title: "Name", Width: 15},
-			{Title: "Host", Width: 15},
-			{Title: "Port", Width: 10},
-			{Title: "User", Width: 10},
-			{Title: "Key", Width: 10},
+			{Title: "Name"},
+			{Title: "Host"},
+			{Title: "Port"},
+			{Title: "User"},
+			{Title: "Key"},
 		}...)
 	}
 
 	if what == SelectHistory {
 		columns = append(columns, []table.Column{
-			{Title: "Name", Width: 10},
-			{Title: "Host", Width: 15},
-			{Title: "Port", Width: 4},
-			{Title: "User", Width: 10},
-			{Title: "Key", Width: 10},
-			{Title: "Last login", Width: 15},
+			{Title: "Name"},
+			{Title: "Host"},
+			{Title: "Port"},
+			{Title: "User"},
+			{Title: "Key"},
+			{Title: "Last login"},
 		}...)
 	}
+
+	columns = theme.CalculateColumnWidths(rows, columns)
 
 	t := table.New(
 		table.WithColumns(columns),
@@ -126,6 +128,7 @@ func Select(rows []table.Row, what Selecting) config.SSHConfig {
 
 	return config.SSHConfig{}
 }
+
 func (m model) HelpView() string {
 
 	km := table.DefaultKeyMap()

--- a/internal/theme/tables.go
+++ b/internal/theme/tables.go
@@ -12,18 +12,45 @@ const (
 	PrintHistory
 )
 
+func CalculateColumnWidths(rows []table.Row, columns []table.Column) []table.Column {
+	padding := 2
+	maxWidths := make([]int, len(columns))
+	for i, col := range columns {
+		maxWidths[i] = len(col.Title) + padding
+	}
+
+	for _, row := range rows {
+		for i, cell := range row {
+			if i < len(maxWidths) {
+				width := len(cell) + padding
+				if width > maxWidths[i] {
+					maxWidths[i] = width
+				}
+			}
+		}
+	}
+
+	for i := range columns {
+		columns[i].Width = maxWidths[i]
+	}
+
+	return columns
+}
+
 func PrintTable(rows []table.Row, p Print) string {
 	columns := []table.Column{
-		{Title: "Name", Width: 10},
-		{Title: "Host", Width: 15},
-		{Title: "Port", Width: 10},
-		{Title: "User", Width: 10},
-		{Title: "Key", Width: 10},
+		{Title: "Name"},
+		{Title: "Host"},
+		{Title: "Port"},
+		{Title: "User"},
+		{Title: "Key"},
 	}
 
 	if p == PrintHistory {
-		columns = append(columns, table.Column{Title: "Last login", Width: 15})
+		columns = append(columns, table.Column{Title: "Last login"})
 	}
+
+	columns = CalculateColumnWidths(rows, columns)
 
 	t := table.New(
 		table.WithColumns(columns),


### PR DESCRIPTION
Noticed the `host` column in the ggh output was cropped, here is a quick fix by calculating the width of columns using rows content length.

It works in interactive and non-interactive mode

No performance loss :
```
hyperfine -r 20 -N -w 5 './ggh --config' 'ggh --config'
Benchmark 1: ./ggh --config
  Time (mean ± σ):       1.7 ms ±   0.1 ms    [User: 1.0 ms, System: 0.6 ms]
  Range (min … max):     1.6 ms …   1.9 ms    20 runs
 
Benchmark 2: ggh --config
  Time (mean ± σ):       1.9 ms ±   0.1 ms    [User: 0.9 ms, System: 0.5 ms]
  Range (min … max):     1.7 ms …   2.0 ms    20 runs
 
Summary
  ./ggh --config ran
    1.08 ± 0.08 times faster than ggh --config
```

Fix https://github.com/byawitz/ggh/issues/19