### PR TITLE
Remove duplicate SSH history entries, keeping the latest for each host

### DIFF
--- a/cmd/ggh.go
+++ b/cmd/ggh.go
@@ -29,8 +29,7 @@ func Main() {
 		config.Print()
 		return
 	default:
-
+		history.AddHistoryFromArgs(args)
 	}
-	history.AddHistoryFromArgs(args)
 	ssh.Run(args)
 }

--- a/internal/history/fetch.go
+++ b/internal/history/fetch.go
@@ -39,7 +39,9 @@ func Fetch(file []byte) ([]SSHHistory, error) {
 
 	for i, history := range historyList {
 		for _, sshConfig := range search {
-			if sshConfig.Host == history.Connection.Host {
+			if sshConfig.Host == history.Connection.Host &&
+				sshConfig.Port == history.Connection.Port &&
+				sshConfig.User == history.Connection.User {
 				historyList[i].Connection.Name = sshConfig.Name
 			}
 		}

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -29,6 +29,7 @@ func Config(value string) []string {
 		})
 	}
 	c := Select(rows, SelectConfig)
+	history.AddHistory(c)
 	return ssh.GenerateCommandArgs(c)
 }
 
@@ -57,5 +58,6 @@ func History() []string {
 		})
 	}
 	c := Select(rows, SelectHistory)
+	history.AddHistory(c)
 	return ssh.GenerateCommandArgs(c)
 }

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -44,9 +44,18 @@ func History() []string {
 		os.Exit(0)
 	}
 
+	// clean list for duplicates, keep the latest
+	uniqueList := map[string]history.SSHHistory{}
+	for _, h := range list {
+		uniqueKey := h.Connection.Host + h.Connection.User + h.Connection.Port
+		if existing, ok := uniqueList[uniqueKey]; !ok || h.Date.After(existing.Date) {
+			uniqueList[uniqueKey] = h // Update with the latest history entry
+		}
+	}
+
 	var rows []table.Row
 	currentTime := time.Now()
-	for _, historyItem := range list {
+	for _, historyItem := range uniqueList {
 		rows = append(rows, table.Row{
 			historyItem.Connection.Name,
 			historyItem.Connection.Host,

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -2,13 +2,14 @@ package interactive
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"time"
+
 	"github.com/byawitz/ggh/internal/config"
 	"github.com/byawitz/ggh/internal/history"
 	"github.com/byawitz/ggh/internal/ssh"
 	"github.com/charmbracelet/bubbles/table"
-	"log"
-	"os"
-	"time"
 )
 
 func Config(value string) []string {
@@ -30,7 +31,10 @@ func Config(value string) []string {
 	}
 	c := Select(rows, SelectConfig)
 	history.AddHistory(c)
-	return ssh.GenerateCommandArgs(c)
+	if c.Name == "" {
+		return ssh.GenerateCommandArgs(c)
+	}
+	return []string{c.Name}
 }
 
 func History() []string {
@@ -59,5 +63,8 @@ func History() []string {
 	}
 	c := Select(rows, SelectHistory)
 	history.AddHistory(c)
-	return ssh.GenerateCommandArgs(c)
+	if c.Name == "" {
+		return ssh.GenerateCommandArgs(c)
+	}
+	return []string{c.Name}
 }

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	"log"
 	"os"
+	"sort"
 	"time"
 )
 
@@ -53,9 +54,19 @@ func History() []string {
 		}
 	}
 
+	// Sort the unique list by date
+	var sortedList []history.SSHHistory
+	for _, h := range uniqueList {
+		sortedList = append(sortedList, h)
+	}
+	// Sort by date in descending order
+	sort.Slice(sortedList, func(i, j int) bool {
+		return sortedList[i].Date.After(sortedList[j].Date)
+	})
+
 	var rows []table.Row
 	currentTime := time.Now()
-	for _, historyItem := range uniqueList {
+	for _, historyItem := range sortedList {
 		rows = append(rows, table.Row{
 			historyItem.Connection.Name,
 			historyItem.Connection.Host,

--- a/internal/interactive/select.go
+++ b/internal/interactive/select.go
@@ -58,6 +58,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func setConfig(row table.Row, what Selecting) config.SSHConfig {
 	return config.SSHConfig{
+		Name: row[0],
 		Host: row[1],
 		Port: row[2],
 		User: row[3],


### PR DESCRIPTION
## What's Changed
* Remove duplicate SSH history entries, keeping the latest for each host
* Enhance SSH history matching by including port and user in comparison 
   - Fixed: #10 