### PR TITLE
Preserve advance ssh configs and history improvements and fixes

### DIFF
--- a/cmd/ggh.go
+++ b/cmd/ggh.go
@@ -29,8 +29,7 @@ func Main() {
 		config.Print()
 		return
 	default:
-
+		history.AddHistoryFromArgs(args)
 	}
-	history.AddHistoryFromArgs(args)
 	ssh.Run(args)
 }

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -20,8 +20,13 @@ type SSHConfig struct {
 	Key  string `json:"key"`
 }
 
+const (
+	DirectSSH     = "──────────────"
+	MissingConfig = "❗"
+)
+
 func (c *SSHConfig) IsDirectSSH() bool {
-	return c.Name == ""
+	return c.Name == "" || c.Name == DirectSSH
 }
 
 func (c *SSHConfig) UniqueKey() string {
@@ -29,6 +34,13 @@ func (c *SSHConfig) UniqueKey() string {
 		return c.Name
 	}
 	return fmt.Sprintf("%s%s%s", c.Host, c.Port, c.User)
+}
+
+func (c *SSHConfig) CleanName() {
+	if c.Name == DirectSSH {
+		c.Name = ""
+	}
+	c.Name = strings.TrimPrefix(c.Name, MissingConfig)
 }
 
 func Parse(configFile string) ([]SSHConfig, error) {

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -20,6 +20,17 @@ type SSHConfig struct {
 	Key  string `json:"key"`
 }
 
+func (c *SSHConfig) IsDirectSSH() bool {
+	return c.Name == ""
+}
+
+func (c *SSHConfig) UniqueKey() string {
+	if !c.IsDirectSSH() {
+		return c.Name
+	}
+	return fmt.Sprintf("%s%s%s", c.Host, c.Port, c.User)
+}
+
 func Parse(configFile string) ([]SSHConfig, error) {
 	return ParseWithSearch("", configFile)
 }

--- a/internal/history/fetch.go
+++ b/internal/history/fetch.go
@@ -31,20 +31,6 @@ func Fetch(file []byte) ([]SSHHistory, error) {
 		return nil, err
 	}
 
-	search, err := config.ParseWithSearch("", config.GetConfigFile())
-
-	if err != nil {
-		return historyList, nil
-	}
-
-	for i, history := range historyList {
-		for _, sshConfig := range search {
-			if sshConfig.Host == history.Connection.Host {
-				historyList[i].Connection.Name = sshConfig.Name
-			}
-		}
-	}
-
 	return historyList, nil
 }
 

--- a/internal/history/fetch.go
+++ b/internal/history/fetch.go
@@ -31,6 +31,30 @@ func Fetch(file []byte) ([]SSHHistory, error) {
 		return nil, err
 	}
 
+	search, err := config.ParseWithSearch("", config.GetConfigFile())
+
+	if err != nil {
+		return historyList, nil
+	}
+
+FormatHistoryLoop:
+	for i, historyItem := range historyList {
+		if historyItem.Connection.Name == "" {
+			historyList[i].Connection.Name = config.DirectSSH
+		} else {
+			// Check if the name is in the config file
+			for _, sshConfig := range search {
+				if sshConfig.Name == historyItem.Connection.Name {
+					// Update the config
+					historyList[i].Connection = sshConfig
+					continue FormatHistoryLoop
+				}
+			}
+			// If not, add a missing config prefix
+			historyList[i].Connection.Name = fmt.Sprintf("%s%s", config.MissingConfig, historyItem.Connection.Name)
+		}
+	}
+
 	return historyList, nil
 }
 

--- a/internal/history/save.go
+++ b/internal/history/save.go
@@ -6,7 +6,6 @@ import (
 	"github.com/byawitz/ggh/internal/config"
 	"github.com/charmbracelet/bubbles/table"
 	"os"
-	"slices"
 	"strings"
 	"time"
 )
@@ -109,18 +108,16 @@ func saveFile(n SSHHistory, l []SSHHistory) error {
 func stringify(n SSHHistory, l []SSHHistory) string {
 	history := make([]SSHHistory, 0)
 
-	for i, sshHistory := range l {
-		if sshHistory.Connection.Host == n.Connection.Host &&
-			sshHistory.Connection.Name == n.Connection.Name {
-			l = slices.Delete(l, i, i+1)
-		}
-	}
-
 	if n.Connection.Host != "" {
 		history = append(history, n)
 	}
 
-	history = append(history, l...)
+	for _, sshHistory := range l {
+		if sshHistory.Connection.UniqueKey() != n.Connection.UniqueKey() {
+			history = append(history, sshHistory)
+		}
+	}
+
 	content, err := json.Marshal(history)
 
 	if err != nil {

--- a/internal/history/save.go
+++ b/internal/history/save.go
@@ -109,7 +109,6 @@ func stringify(n SSHHistory, l []SSHHistory) string {
 	history := make([]SSHHistory, 0)
 
 	if n.Connection.Host != "" {
-		n.Connection.CleanName()
 		history = append(history, n)
 	}
 

--- a/internal/history/save.go
+++ b/internal/history/save.go
@@ -109,10 +109,12 @@ func stringify(n SSHHistory, l []SSHHistory) string {
 	history := make([]SSHHistory, 0)
 
 	if n.Connection.Host != "" {
+		n.Connection.CleanName()
 		history = append(history, n)
 	}
 
 	for _, sshHistory := range l {
+		sshHistory.Connection.CleanName()
 		if sshHistory.Connection.UniqueKey() != n.Connection.UniqueKey() {
 			history = append(history, sshHistory)
 		}

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -29,6 +29,7 @@ func Config(value string) []string {
 		})
 	}
 	c := Select(rows, SelectConfig)
+	history.AddHistory(c)
 	return ssh.GenerateCommandArgs(c)
 }
 
@@ -57,5 +58,6 @@ func History() []string {
 		})
 	}
 	c := Select(rows, SelectHistory)
+	history.AddHistory(c)
 	return ssh.GenerateCommandArgs(c)
 }

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -30,7 +30,7 @@ func Config(value string) []string {
 	}
 	c := Select(rows, SelectConfig)
 	history.AddHistory(c)
-	return ssh.GenerateCommandArgs(c)
+	return []string{c.Name}
 }
 
 func History() []string {
@@ -59,5 +59,8 @@ func History() []string {
 	}
 	c := Select(rows, SelectHistory)
 	history.AddHistory(c)
-	return ssh.GenerateCommandArgs(c)
+	if c.IsDirectSSH() {
+		return ssh.GenerateCommandArgs(c)
+	}
+	return []string{c.Name}
 }

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -58,6 +58,7 @@ func History() []string {
 		})
 	}
 	c := Select(rows, SelectHistory)
+	c.CleanName()
 	history.AddHistory(c)
 	if c.IsDirectSSH() {
 		return ssh.GenerateCommandArgs(c)

--- a/internal/interactive/select.go
+++ b/internal/interactive/select.go
@@ -58,6 +58,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func setConfig(row table.Row, what Selecting) config.SSHConfig {
 	return config.SSHConfig{
+		Name: row[0],
 		Host: row[1],
 		Port: row[2],
 		User: row[3],


### PR DESCRIPTION
* Fix: wrong history retrieved bug #10 
* Adding missing config prefix 
* Adding placeholder for direct ssh
* Updating the history connection info if a name match was found in the configs.
* Use Name instead of building a new connection params. preserve advance ssh configs