### PR TITLE
fixed bug with key disappearing when reconnecting

### DIFF
--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -24,7 +24,7 @@ func GenerateCommandArgs(c config.SSHConfig) []string {
 	if c.Port != "" {
 		port = "-p " + c.Port
 	}
-	return strings.Split(fmt.Sprintf("%s@%s %s %s", user, c.Host, key, port), " ")
+	return strings.Split(fmt.Sprintf("%s %s@%s %s", key, user, c.Host, port), " ")
 }
 
 func Run(args []string) {


### PR DESCRIPTION
The key must be the first argument if a custom port is specified, otherwise the key field becomes empty upon reconnection.