### PR TITLE
Added memoriom tribute for @byawitz

### DIFF
--- a/cmd/ggh.go
+++ b/cmd/ggh.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/byawitz/ggh/internal/command"
 	"github.com/byawitz/ggh/internal/config"
 	"github.com/byawitz/ggh/internal/history"
@@ -13,6 +14,8 @@ func Main() {
 	command.CheckSSH()
 
 	args := os.Args[1:]
+
+	fmt.Println("\033[2mIn memory of Binymin Yawitz (1990–2025), creator of GGH \033[31m❤️\033[0m\033[2m\033[0m")
 
 	action, value := command.Which()
 	switch action {

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -44,7 +44,7 @@ func History() []string {
 		os.Exit(0)
 	}
 
-	fmt.Println("\033[2mIn memory of Binymin Yawitz (1989–2025), creator of GGH \033[31m❤️\033[0m\033[2m\033[0m")
+	fmt.Println("\033[2mIn memory of Binymin Yawitz (1990–2025), creator of GGH \033[31m❤️\033[0m\033[2m\033[0m")
 
 	var rows []table.Row
 	currentTime := time.Now()

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -44,8 +44,6 @@ func History() []string {
 		os.Exit(0)
 	}
 
-	fmt.Println("\033[2mIn memory of Binymin Yawitz (1990–2025), creator of GGH \033[31m❤️\033[0m\033[2m\033[0m")
-
 	var rows []table.Row
 	currentTime := time.Now()
 	for _, historyItem := range list {

--- a/internal/interactive/display.go
+++ b/internal/interactive/display.go
@@ -44,6 +44,8 @@ func History() []string {
 		os.Exit(0)
 	}
 
+	fmt.Println("\033[2mIn memory of Binymin Yawitz (1989–2025), creator of GGH \033[31m❤️\033[0m\033[2m\033[0m")
+
 	var rows []table.Row
 	currentTime := time.Now()
 	for _, historyItem := range list {


### PR DESCRIPTION
:dove: In Memory of Binymin Yawitz (1990–2025)

It is with deep sadness that I share the news of Binyamin Yawitz’s (@byawitz) passing at the age of 34.

Binymin was not only the creator of ggh, but also a lifelong friend. We knew each other since childhood, and I had the privilege of witnessing firsthand his brilliance, kindness, and dedication — both as a developer and as a human being.

### :bulb: Pull Request: Add Tribute to CLI Output

**Summary:**  
This PR adds a tribute message to the CLI output of `ggh` in memory of Binyamin Yawitz. The message includes his name, life dates, and a red heart rendered with ANSI color codes, and appears at runtime to honor his role in creating this tool.

**Example Output:**
In memory of Binyamin Yawitz (1990–2025), creator of GGH :heart:

(Heart is shown in red in supported terminals.)

**Why This Matters:**  
Binyamin believed in sharing knowledge and empowering others, and `ggh` reflects that spirit of open source and generosity. This small tribute keeps his name visible in the project he started and acknowledges the impact he had. For me personally, it's also a way to honor the memory of a dear friend I've known for most of my life.

**Implementation Notes:**
- Message uses ANSI escape sequences to render the heart in red.
- Displayed on every run of `ggh`, early in the output stream.
- The message is concise, respectful, and visually subtle.

I’m open to any suggestions if the community would prefer a different placement or conditional display (e.g. behind a flag).